### PR TITLE
Fix everett usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=6.0', 'pyyaml', 'boto3', 'everett', 'botocore', 'Jinja2>=2.10', 'docker', 'prompt-toolkit']
+requirements = ['Click>=6.0', 'pyyaml', 'boto3', 'everett[ini]', 'botocore', 'Jinja2>=2.10', 'docker', 'prompt-toolkit']
 
 setup_requirements = ['pytest-runner']
 

--- a/ssm_acquire/common.py
+++ b/ssm_acquire/common.py
@@ -1,7 +1,7 @@
 import os
 import json
 import yaml
-from everett.manager import ConfigIniEnv
+from everett.ext.inifile import ConfigIniEnv
 from everett.manager import ConfigManager
 from everett.manager import ConfigOSEnv
 from jinja2 import Template


### PR DESCRIPTION
Installing from master results in the following:

Error:
```
(venv) ubuntu@ip-172-31-27-252:~$ ssm_acquire
Traceback (most recent call last):
  File "/home/ubuntu/venv/bin/ssm_acquire", line 11, in <module>
    load_entry_point('ssm-acquire==0.1.0.4', 'console_scripts', 'ssm_acquire')()
  File "/home/ubuntu/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/ubuntu/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/home/ubuntu/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/home/ubuntu/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/ubuntu/venv/lib/python3.6/site-packages/ssm_acquire/__init__.py", line 9, in <module>
    from ssm_acquire import analyze
  File "/home/ubuntu/venv/lib/python3.6/site-packages/ssm_acquire/analyze.py", line 8, in <module>
    from ssm_acquire import common
  File "/home/ubuntu/venv/lib/python3.6/site-packages/ssm_acquire/common.py", line 4, in <module>
    from everett.manager import ConfigIniEnv
ImportError: cannot import name 'ConfigIniEnv'
```

It seems like something in everett might have changed since this project was last updated. Everett docs show: `from everett.ext.inifile import ConfigIniEnv` as the proper import statement, while ssm-acquire tries `from everett.manager import ConfigIniEnv`, which fails.

Though, making that correction leads to more errors -- it seems you need `everett[ini]` which pulls in additional deps.

This PR makes both of those fixes. I haven't tested full functionality, but this at least lets you run `ssm_acquire --help` without errors and the test suite passes (except for tests that fail with `FileNotFoundError: [Errno 2] No such file or directory: 'tests/fixtures/interrogation.log'` which is unrelated).
